### PR TITLE
MultiDex优化

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ dependencyResolutionManagement {
 ```groovy
 // 协程库(版本可自定)
 implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1'
-// OkHttp3.12.x(限此版本号以下)
-implementation 'com.squareup.okhttp3:okhttp:3.12.0'
+
 // Net
+// 介于okhttp 3.12.x的更新情况，Net-okhttp3已内置okhttp3:3.12.13，无需再单独引入。
 implementation 'com.github.liangjingkanji:Net-okhttp3:3.4.6'
 
 // 支持自动下拉刷新和缺省页的(可选)

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ buildscript {
         coroutine_version = '1.5.1'
         glide_version = '4.11.0'
         room_version = "2.3.0"
-        okhttp_version = "3.12.0"
+        okhttp_version = "3.12.13"
     }
 
     repositories {

--- a/net/build.gradle
+++ b/net/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     androidTestImplementation "androidx.test:runner:1.3.0"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.3.0"
 
-    compileOnly "com.squareup.okhttp3:okhttp:$okhttp_version"
+    api "com.squareup.okhttp3:okhttp:$okhttp_version"
 
     compileOnly "com.github.liangjingkanji:BRV:$brv_version"
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutine_version"

--- a/net/src/main/java/com/drake/net/utils/LegacyTLS.kt
+++ b/net/src/main/java/com/drake/net/utils/LegacyTLS.kt
@@ -1,0 +1,22 @@
+package com.drake.net.utils
+
+import android.os.Build
+import okhttp3.CipherSuite
+import okhttp3.ConnectionSpec
+import okhttp3.OkHttpClient
+
+/**
+ * API<21 支持 TLSv1.1 和 TLSv1.2
+ */
+fun OkHttpClient.Builder.useLegacyTLS() {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        val legacyTls: ConnectionSpec = ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
+            .cipherSuites(
+                *ConnectionSpec.MODERN_TLS.cipherSuites()?.toTypedArray() ?: emptyArray(),
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+                CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+            ).build()
+
+        connectionSpecs(listOf(legacyTls, ConnectionSpec.CLEARTEXT))
+    }
+}

--- a/sample/src/main/java/com/drake/net/sample/base/App.kt
+++ b/sample/src/main/java/com/drake/net/sample/base/App.kt
@@ -16,7 +16,7 @@
 
 package com.drake.net.sample.base
 
-import android.app.Application
+import androidx.multidex.MultiDexApplication
 import com.chuckerteam.chucker.api.ChuckerCollector
 import com.chuckerteam.chucker.api.ChuckerInterceptor
 import com.drake.brv.BindingAdapter
@@ -40,7 +40,7 @@ import com.scwang.smart.refresh.layout.SmartRefreshLayout
 import okhttp3.Cache
 import java.util.concurrent.TimeUnit
 
-class App : Application() {
+class App : MultiDexApplication() {
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
1. 既然是 `<API21` 专用，那么sample的App需继承`MultiDexApplication`(或其它实现方法)，否则必崩[MultiDex](https://developer.android.com/studio/build/multidex?hl=zh-cn#mdex-gradle)。

2. 由于app 依赖 Net-okhttp3 仅编译时依赖 okhttp3，导致启动时若直接调用Net大概率会导致`NoClassDefFoundError` or `NoSuchMethodError`。原因为`MultiDex`并不一定100%能处理好复杂依赖情况。最佳解决办法当然是[multiDexKeepFile](https://developer.android.com/studio/build/multidex?hl=zh-cn#multidexkeepfile-property)，这样对于用户可以随时更新依赖的`okhttp`版本。但是对于一个已经基本宣布不再更新的`okhttp:3.12.x`，这里可以直接使用api来依赖，降低集成难度。square在okhttp:3.12.10时也说明了这个问题 -> [Supporting a full decade of Android releases on our 3.12.x branch is tricky!](https://square.github.io/okhttp/changelogs/changelog_3x/#version-31210)

3. 由于API21开始才默认开启TLSv1.1和TLSv1.2，所以新增了一个`useLegacyTLS()`的方法。用于快捷解决`javax.net.ssl.SSLProtocolException: SSL handshake aborted: ssl=0xb82109a0: Failure in SSL library, usually a protocol error`。[okhttp issues #4053](https://github.com/square/okhttp/issues/4053)
```kotlin
   NetConfig.initialize(...){
       ...
       useLegacyTLS()
   }
```


题外话: 我看了下com.drake.net.compatible.OkHttpClient 是2022-04-22 #d26e1068 新增了一些扩展，用于适配okhttp4.x的一些习惯，但是2022-04-30 [Net-okhttp3:3.4.6](https://jitpack.io/com/github/liangjingkanji/Net-okhttp3/3.4.6/build.log)的包里却没有这些扩展...

![](https://user-images.githubusercontent.com/15992858/170669829-03de8f2e-9842-4a86-9c2d-0b995707a0c0.png)

